### PR TITLE
add missing semi colons from js hints

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,7 @@ function keyDown(e) {
   else if (e.keyCode == 32) {
     run();
   }
-};
+}
 
 function keyUp(e) {
   if(e.keyCode == 39) {
@@ -25,12 +25,12 @@ function keyUp(e) {
   else if(e.keyCode == 37) {
     game.paddle.moveLeft = false;
   }
-};
+}
 
 function run() {
   game.timing();
 
   requestAnimationFrame(run);
-};
+}
 
 game.load();

--- a/test/ball-test.js
+++ b/test/ball-test.js
@@ -38,13 +38,13 @@ describe ('Ball', function(){
     // The ball should have a move function
     it('Ball should have a move function', function(){
       assert.isFunction(ball.moveBall);
-    })
+    });
 
     // The ball should move in the move function
     it('Ball should move in the move function by incrementing the x and decrementing the y', function(){
       ball.moveBall();
-      assert.equal(ball.x, 282)
-      assert.equal(ball.y, 568)
+      assert.equal(ball.x, 282);
+      assert.equal(ball.y, 568);
     });
   });
 });


### PR DESCRIPTION
More clean up! We only have issues with our conditionals now. No more semi colon issues. 